### PR TITLE
Automate versioning for tags

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,27 +1,16 @@
----
-name: Tag
-
-on:                # yamllint disable-line rule:truthy
+name: Bump version
+on:
   push:
     branches:
       - main
-
 jobs:
-  ## tag
-  tag:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set GIT_TAG
-        run: |
-          echo "VERSION=$(cat .version | tr -d " \t\n\r")" >> $GITHUB_ENV
-
-      - name: git-tag
-        uses: pkgdeps/git-tag-action@v2.0.1
-        with:
-          version: ${{ env.VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_repo: ${{ github.repository }}
-          git_commit_sha: ${{ github.sha }}
-          git_tag_prefix: ""
+    - uses: actions/checkout@master
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: patch
+        REPO_OWNER: sourcefuse


### PR DESCRIPTION
Here is a workflow
It works like this

Default bump is patch right now
But if there is a minor or major change then while doing commit you need to specify `#minor` `#major` then it will update the version accordingly and no need of version file is required 

`git commit -m "Added tag.yml  #minor"`

@jamescrowley321  @tsaucier-sf  let me know if that works for you.

If you dont specify #minor. #major or #patch while doing commit then it will use default that is given in workflow file
We can also Disable this by setting DEFAULT_BUMP to none.

right now the current tag is `2.0.2` after merging this PR the tag will be updated to `2.0.3`
Taken reference from here

https://github.com/marketplace/actions/github-tag-bump
