### PR TITLE
Cloudfront - Fix for ACM region

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,8 @@ repos:
     rev: v1.77.1
     hooks:
       - id: terraform_validate
-      # - id: terraform_tflint TODO: enable it after fixing "Error: Optional object type attributes are experimental"
+        files: example/
+      - id: terraform_tflint
       - id: terraform_fmt
         args:
           - --args=-recursive

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ module "cloudfront" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws.acm"></a> [aws.acm](#provider\_aws.acm) | 4.67.0 |
 
 ## Modules
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -12,6 +12,10 @@ module "tags" {
 module "cloudfront" {
   source = "../"
 
+  providers = {
+    aws.acm = aws.acm
+  }
+
   origins = [{
     origin_type   = "custom",
     origin_id     = "cloudfront-arc",

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -16,3 +16,8 @@ provider "aws" {
   region = "us-east-1"
   alias  = "lambda_at_edge"
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "acm"
+}

--- a/route53-acm.tf
+++ b/route53-acm.tf
@@ -8,6 +8,7 @@ resource "aws_acm_certificate" "this" {
   domain_name               = var.acm_details.domain_name
   validation_method         = "DNS"
   subject_alternative_names = var.acm_details.subject_alternative_names
+  provider                  = aws.acm
 
   tags = var.tags
 }
@@ -42,6 +43,7 @@ resource "aws_acm_certificate_validation" "this" {
   count                   = var.acm_details.domain_name == "" ? 0 : 1
   certificate_arn         = aws_acm_certificate.this[0].arn
   validation_record_fqdns = [for record in aws_route53_record.this : record.fqdn]
+  provider                = aws.acm
 
   depends_on = [aws_route53_record.this]
 }

--- a/version.tf
+++ b/version.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
+      source                = "hashicorp/aws"
+      version               = "~> 4.0"
+      configuration_aliases = [aws.acm]
     }
   }
 }


### PR DESCRIPTION
**Issue**
- ACM work only on us-east-1 region.

- Added support for passing provider